### PR TITLE
Add config to exclude session keys from log

### DIFF
--- a/config/admin-log.php
+++ b/config/admin-log.php
@@ -15,4 +15,8 @@ return [
     'cleanup' => [
         'retain_for_days' => 365,
     ],
+    /**
+     * Session keys to exclude from session field when saving request to db
+     */
+    'session_blacklist_keys' => [],
 ];

--- a/src/Http/Middleware/LogAdminRequests.php
+++ b/src/Http/Middleware/LogAdminRequests.php
@@ -32,6 +32,7 @@ class LogAdminRequests
     public function __construct(Sentinel $sentinel)
     {
         $this->sentinel = $sentinel;
+        $this->config = config('admin-log');
     }
 
     /**
@@ -54,10 +55,23 @@ class LogAdminRequests
             'user_agent' => $request->userAgent(),
             'http_content_type' => $request->getContentType(),
             'http_cookie' => serialize($sanitizer->sanitize($request->cookies->all())),
-            'session' => serialize($sanitizer->sanitize($request->session()->all())),
+            'session' => serialize($sanitizer->sanitize($this->getSession())),
             'content' => serialize($sanitizer->sanitize($request->all())),
         ]);
 
         return $next($request);
     }
+
+    /**
+     * @return array
+     */
+    private function getSession()
+    {
+        $session = request()->session()->all();
+
+        return collect($session)
+            ->except($this->config['session_blacklist_keys'])
+            ->toArray();
+    }
+
 }


### PR DESCRIPTION
Adds config to exclude session keys from log to avoid db errors due to too long values